### PR TITLE
Fix for DeprecationWarning: crypto.pbkdf2 - NodeJS v6+

### DIFF
--- a/lib/passport-local-mongoose-email.js
+++ b/lib/passport-local-mongoose-email.js
@@ -8,6 +8,7 @@ module.exports = function(schema, options) {
     options.saltlen = options.saltlen || 32;
     options.iterations = options.iterations || 25000;
     options.keylen = options.keylen || 512;
+    options.digest = options.digest || 'SHA1';
     options.encoding = options.encoding || 'hex';
 
     // Populate field names with defaults if not set
@@ -62,7 +63,7 @@ module.exports = function(schema, options) {
 
             var salt = buf.toString(options.encoding);
 
-            crypto.pbkdf2(password, salt, options.iterations, options.keylen, function(err, hashRaw) {
+            crypto.pbkdf2(password, salt, options.iterations, options.keylen, options.digest, function(err, hashRaw) {
                 if (err) {
                     return cb(err);
                 }
@@ -99,7 +100,7 @@ module.exports = function(schema, options) {
             return cb(null, false, { message: options.noSaltValueStoredError });
         }
 
-        crypto.pbkdf2(password, this.get(options.saltField), options.iterations, options.keylen, function(err, hashRaw) {
+        crypto.pbkdf2(password, this.get(options.saltField), options.iterations, options.keylen, options.digest, function(err, hashRaw) {
             if (err) {
                 return cb(err);
             }


### PR DESCRIPTION
Fix for DeprecationWarning: crypto.pbkdf2 without specifying a digest is deprecated. Please specify a digest

This is for future NodeJS builds v6+ where crypto now needs a digest.
For backwards compatibility we use the SHA1 digest.
